### PR TITLE
Add files via upload

### DIFF
--- a/DFA.cpp
+++ b/DFA.cpp
@@ -70,10 +70,9 @@ bool DFA::setTerminal(int id)
 
     //deallocate old memory
     delete[] terminal;
-    numOfTerminalStates++;
-    terminal = new int[numOfTerminalStates];
     terminal = temp;
 
+    numOfTerminalStates++;
     cout << id << " is now a final state" << endl;
     return 1;
 }

--- a/DFA.cpp
+++ b/DFA.cpp
@@ -70,9 +70,10 @@ bool DFA::setTerminal(int id)
 
     //deallocate old memory
     delete[] terminal;
+    numOfTerminalStates++;
+    terminal = new int[numOfTerminalStates];
     terminal = temp;
 
-    numOfTerminalStates++;
     cout << id << " is now a final state" << endl;
     return 1;
 }

--- a/DFA.cpp
+++ b/DFA.cpp
@@ -33,15 +33,16 @@ bool DFA::isTerminal(int id)
 
 bool DFA::setInitial(int id)
 {
-    if (findpos(id) == -1)
+    int temp = findpos(id);
+    if (temp == -1)
     {
         cout << "Could not find a state with given id" << endl;
         return 0;
     }
 
-    initial = findpos(id);
+    initial = temp;
     cout << id << " is now the initial state" << endl;
-    currentState = states[findpos(id)];
+    currentState = states[initial];
     return 1;
 }
 
@@ -67,9 +68,11 @@ bool DFA::setTerminal(int id)
     }
     temp[i] = id;
 
-    numOfTerminalStates++;
-    terminal = new int[numOfTerminalStates];
+    //deallocate old memory
+    delete[] terminal;
     terminal = temp;
+
+    numOfTerminalStates++;
     cout << id << " is now a final state" << endl;
     return 1;
 }


### PR DESCRIPTION
1) By using a variable "temp" to hold findpos(id) return value, Time complexity can be reduced and algorithm gets rid of two O(n) searches in setInitial( )
2) Delete old table of terminal_states in setTerminal( ) and avoid memory leakage
3) In setTerminal( ) there is no need reallocate space for new terminal_states, as this has been done by "temp = new [...]". temp's content isn't going to be lost. Again, that command leads to memory leakage.